### PR TITLE
Fix minor details in dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# docker related files
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:buster-slim
+FROM node:15.4.0-buster-slim
 
 ARG USER_UID="1001"
 ARG USER_GID="1001"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ dentro del mismo directorio del repositorio.
 
 Para correr la imagen hacemos:
 
-* `docker run -d -p 8080:80 --name mallas malla-interactiva`
+* `docker run -d -p 8080:8080 --name mallas malla-interactiva`
 
 Y luego podemos visitar nuestra malla en [http://localhost:8080/](http://localhost:8080/).
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
   "dependencies": {
   },
   "devDependencies": {
-    "browsersync": "0.0.1-security"
+    "browsersync": "0.0.1-security",
+    "terser": "^5.5.1",
+    "uglifycss": "^0.0.29"
   },
   "scripts": {
+    "build": "./scripts/minify_code.sh",
+    "clean": "npm prune --production",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Proyecto Universitario en donde se mantiene una plataforma web que facilita información sobre las mallas en la Universidad.",
   "main": "index.html",
   "dependencies": {
-    "terser": "^5.5.1"
   },
   "devDependencies": {
     "browsersync": "0.0.1-security"


### PR DESCRIPTION
Arrregla el issue #11 e incidentemente el #12 debido a que ahora corremos el proceso dentro del container como un usuario no privilegiado. Por lo mismo, esta imagen puede ser levantada con `--cap-drop=all` sin problemas. Además de dejar _pinneada_ la versión base de la imagen (puesto que será usada en producción), también arregla el puerto al correcto (8080) mostrado en las instrucciones de uso en el README y remueve `terser` como dependencia dentro de `package.json`: es requerido solo dentro del container en _build-time_ para uso en la _command-line_, no dentro del código en sí.